### PR TITLE
Implement multi-college management with college admin roles and internal course seeding

### DIFF
--- a/prisma/migrations/20260423212044_add_user_college_code/migration.sql
+++ b/prisma/migrations/20260423212044_add_user_college_code/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "Role" ADD VALUE 'COLLEGE_ADMIN';
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "collegeCode" "College";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
     role             Role      @default(STUDENT)
     phone            String?
     departmentCode   String?
+    collegeCode      College?
     isActive         Boolean   @default(true)
     lastLoginAt      DateTime?
     resetToken       String?   @unique
@@ -171,6 +172,7 @@ enum Role {
     STUDENT
     LECTURER
     HOD
+    COLLEGE_ADMIN
     ADMIN
 }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { ComplaintsModule } from './modules/complaints/complaints.module';
 import { HealthModule } from './modules/health/health.module';
 import { RolesGuard } from './common/guards/roles.guard';
 import { HodDepartmentGuard } from './common/guards/hod-department.guard';
+import { CollegeAdminGuard } from './common/guards/college-admin.guard';
 import { AcademicSessionsModule } from './modules/academic-sessions/academic-sessions.module';
 import { ExamsModule } from './modules/exams/exams.module';
 import { CourseAliasesModule } from './modules/course-aliases/course-aliases.module';
@@ -55,6 +56,7 @@ import { AdminModule } from './modules/admin/admin.module';
     { provide: APP_GUARD, useClass: ThrottlerGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
     { provide: APP_GUARD, useClass: HodDepartmentGuard },
+    { provide: APP_GUARD, useClass: CollegeAdminGuard },
   ],
 })
 export class AppModule {}

--- a/src/common/decorators/skip-college-guard.decorator.ts
+++ b/src/common/decorators/skip-college-guard.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SKIP_COLLEGE_GUARD_KEY = 'skip_college_guard';
+export const SkipCollegeGuard = () => SetMetadata(SKIP_COLLEGE_GUARD_KEY, true);

--- a/src/common/guards/college-admin.guard.ts
+++ b/src/common/guards/college-admin.guard.ts
@@ -75,8 +75,8 @@ export class CollegeAdminGuard implements CanActivate {
   ): Promise<College | null> {
     const { params, body } = request;
 
-    if (body?.college) return body.college as College;
-    if (body?.collegeCode) return body.collegeCode as College;
+    if (body?.college) return body.college;
+    if (body?.collegeCode) return body.collegeCode;
 
     if (body?.departmentCode) {
       const dept = await this.prisma.department.findUnique({

--- a/src/common/guards/college-admin.guard.ts
+++ b/src/common/guards/college-admin.guard.ts
@@ -1,0 +1,131 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { PrismaService } from '../../modules/database/prisma.service';
+import { College, Role } from '../../generated/prisma';
+import { SKIP_COLLEGE_GUARD_KEY } from '../decorators/skip-college-guard.decorator';
+
+interface RequestWithUser {
+  user?: {
+    id: string;
+    role: Role;
+    email: string;
+    collegeCode?: College;
+  };
+  params?: { code?: string; id?: string };
+  body?: {
+    departmentCode?: string;
+    courseCode?: string;
+    college?: College;
+    collegeCode?: College;
+  };
+  method: string;
+}
+
+@Injectable()
+export class CollegeAdminGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const skip = this.reflector.getAllAndOverride<boolean>(
+      SKIP_COLLEGE_GUARD_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (skip) return true;
+
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const { user, method } = request;
+
+    if (!user || user.role !== Role.COLLEGE_ADMIN) return true;
+    if (method === 'GET') return true;
+
+    if (!user.collegeCode) {
+      throw new ForbiddenException(
+        'College admin must be assigned to a college',
+      );
+    }
+
+    const resourceCollege = await this.resolveResourceCollege(request);
+
+    if (resourceCollege === null) {
+      throw new ForbiddenException(
+        'College admins can only modify resources within their own college',
+      );
+    }
+
+    if (resourceCollege !== user.collegeCode) {
+      throw new ForbiddenException(
+        `College admins can only modify resources within their own college (${user.collegeCode})`,
+      );
+    }
+
+    return true;
+  }
+
+  private async resolveResourceCollege(
+    request: RequestWithUser,
+  ): Promise<College | null> {
+    const { params, body } = request;
+
+    if (body?.college) return body.college as College;
+    if (body?.collegeCode) return body.collegeCode as College;
+
+    if (body?.departmentCode) {
+      const dept = await this.prisma.department.findUnique({
+        where: { code: body.departmentCode },
+        select: { college: true },
+      });
+      return dept?.college ?? null;
+    }
+
+    if (body?.courseCode) {
+      const course = await this.prisma.course.findUnique({
+        where: { code: body.courseCode },
+        include: { department: { select: { college: true } } },
+      });
+      return course?.department?.college ?? null;
+    }
+
+    if (params?.code) {
+      const dept = await this.prisma.department.findUnique({
+        where: { code: params.code },
+        select: { college: true },
+      });
+      if (dept) return dept.college;
+
+      const course = await this.prisma.course.findUnique({
+        where: { code: params.code },
+        include: { department: { select: { college: true } } },
+      });
+      if (course) return course.department?.college ?? null;
+    }
+
+    if (params?.id) {
+      const schedule = await this.prisma.schedule.findUnique({
+        where: { id: params.id },
+        include: {
+          course: { include: { department: { select: { college: true } } } },
+        },
+      });
+      if (schedule) return schedule.course.department?.college ?? null;
+
+      const examSchedule = await this.prisma.examSchedule.findUnique({
+        where: { id: params.id },
+        include: {
+          course: { include: { department: { select: { college: true } } } },
+        },
+      });
+      if (examSchedule) return examSchedule.course.department?.college ?? null;
+    }
+
+    return null;
+  }
+}

--- a/src/common/types/auth.types.ts
+++ b/src/common/types/auth.types.ts
@@ -1,12 +1,13 @@
 import { Request } from 'express';
-import { User } from '../../generated/prisma';
+import { College, User } from '../../generated/prisma';
 
 export interface AuthenticatedRequest extends Request {
-  user: User;
+  user: User & { collegeCode?: College };
 }
 
 export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
+  collegeCode?: College;
 }

--- a/src/modules/academic-sessions/academic-sessions.controller.ts
+++ b/src/modules/academic-sessions/academic-sessions.controller.ts
@@ -16,6 +16,7 @@ import { BaseController } from '../../common/controllers/base.controller';
 import { CrudRoles } from '../../common/decorators/crud-roles.decorator';
 import { AcademicSession, Role } from '../../generated/prisma';
 import { PaginationOptions } from '../../common/interfaces/base-service.interface';
+import { SkipCollegeGuard } from '../../common/decorators/skip-college-guard.decorator';
 import {
   ApiActivateSession,
   ApiArchiveSession,
@@ -31,6 +32,7 @@ import {
 @ApiTags('Academic Sessions')
 @ApiBearerAuth('JWT-auth')
 @Controller('academic-sessions')
+@SkipCollegeGuard()
 @CrudRoles({
   create: [Role.ADMIN],
   read: [],

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,63 +1,89 @@
-import { Controller, Delete, Post, Body } from '@nestjs/common';
+import { Controller, Delete, Post, Body, Req } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { AdminService } from './admin.service';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { SkipHodGuard } from '../../common/decorators/skip-hod-guard.decorator';
+import { SkipCollegeGuard } from '../../common/decorators/skip-college-guard.decorator';
 import { Role } from '../../generated/prisma';
+import { AuthenticatedRequest } from '../../common/types/auth.types';
 
 @ApiTags('Admin')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin')
-@Roles(Role.ADMIN)
 @SkipHodGuard()
+@SkipCollegeGuard()
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
   @Delete('schedules')
-  @ApiOperation({ summary: 'Delete all schedules' })
-  deleteAllSchedules() {
-    return this.adminService.deleteAllSchedules();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Delete all schedules (Admin / College Admin)' })
+  deleteAllSchedules(@Req() req: AuthenticatedRequest) {
+    return this.adminService.deleteAllSchedules(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Delete('exam-schedules')
-  @ApiOperation({ summary: 'Delete all exam schedules' })
-  deleteAllExamSchedules() {
-    return this.adminService.deleteAllExamSchedules();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({
+    summary: 'Delete all exam schedules (Admin / College Admin)',
+  })
+  deleteAllExamSchedules(@Req() req: AuthenticatedRequest) {
+    return this.adminService.deleteAllExamSchedules(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Delete('courses')
-  @ApiOperation({ summary: 'Delete all courses' })
-  deleteAllCourses() {
-    return this.adminService.deleteAllCourses();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Delete all courses (Admin / College Admin)' })
+  deleteAllCourses(@Req() req: AuthenticatedRequest) {
+    return this.adminService.deleteAllCourses(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Delete('departments')
-  @ApiOperation({ summary: 'Delete all departments' })
-  deleteAllDepartments() {
-    return this.adminService.deleteAllDepartments();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Delete all departments (Admin / College Admin)' })
+  deleteAllDepartments(@Req() req: AuthenticatedRequest) {
+    return this.adminService.deleteAllDepartments(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Delete('all')
-  @ApiOperation({ summary: 'Delete all data' })
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: 'Delete all data (Super Admin only)' })
   deleteAllData() {
     return this.adminService.deleteAllData();
   }
 
   @Post('seed/departments')
-  @ApiOperation({ summary: 'Seed departments' })
-  seedDepartments() {
-    return this.adminService.seedDepartments();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Seed departments (Admin / College Admin)' })
+  seedDepartments(@Req() req: AuthenticatedRequest) {
+    return this.adminService.seedDepartments(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Post('seed/courses')
-  @ApiOperation({ summary: 'Seed courses' })
-  seedCourses() {
-    return this.adminService.seedCourses();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Seed courses (Admin / College Admin)' })
+  seedCourses(@Req() req: AuthenticatedRequest) {
+    return this.adminService.seedCourses(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Post('seed/all')
-  @ApiOperation({ summary: 'Seed all data' })
-  seedAll() {
-    return this.adminService.seedAll();
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
+  @ApiOperation({ summary: 'Seed all data (Admin / College Admin)' })
+  seedAll(@Req() req: AuthenticatedRequest) {
+    return this.adminService.seedAll(
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 }

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -3,7 +3,7 @@ import { PrismaService } from '../database/prisma.service';
 import { DEPARTMENTS_SEED } from './seed-data/departments.seed';
 import { UNIVERSITY_COURSES_SEED } from './seed-data/university-courses.seed';
 import { DEPARTMENTAL_COURSES_SEED } from './seed-data/departmental-courses.seed';
-import { Level, Semester } from '../../generated/prisma';
+import { College, Level, Semester } from '../../generated/prisma';
 
 interface SeedCourse {
   code: string;
@@ -17,34 +17,105 @@ interface SeedCourse {
   aliasOf?: string[];
 }
 
+interface SeedDepartment {
+  name: string;
+  code: string;
+  college: College;
+  description?: string;
+}
+
 @Injectable()
 export class AdminService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async deleteAllSchedules(): Promise<{ deleted: number }> {
-    const result = await this.prisma.schedule.deleteMany({});
+  async deleteAllSchedules(
+    collegeScope?: College,
+  ): Promise<{ deleted: number }> {
+    if (!collegeScope) {
+      const result = await this.prisma.schedule.deleteMany({});
+      return { deleted: result.count };
+    }
+
+    const result = await this.prisma.schedule.deleteMany({
+      where: { course: { department: { college: collegeScope } } },
+    });
     return { deleted: result.count };
   }
 
-  async deleteAllExamSchedules(): Promise<{ deleted: number }> {
-    const result = await this.prisma.examSchedule.deleteMany({});
+  async deleteAllExamSchedules(
+    collegeScope?: College,
+  ): Promise<{ deleted: number }> {
+    if (!collegeScope) {
+      const result = await this.prisma.examSchedule.deleteMany({});
+      return { deleted: result.count };
+    }
+
+    const result = await this.prisma.examSchedule.deleteMany({
+      where: { course: { department: { college: collegeScope } } },
+    });
     return { deleted: result.count };
   }
 
-  async deleteAllCourses(): Promise<{ deleted: number }> {
-    await this.prisma.schedule.deleteMany({});
-    await this.prisma.examSchedule.deleteMany({});
-    await this.prisma.courseAlias.deleteMany({});
-    const result = await this.prisma.course.deleteMany({});
+  async deleteAllCourses(collegeScope?: College): Promise<{ deleted: number }> {
+    if (!collegeScope) {
+      await this.prisma.schedule.deleteMany({});
+      await this.prisma.examSchedule.deleteMany({});
+      await this.prisma.courseAlias.deleteMany({});
+      const result = await this.prisma.course.deleteMany({});
+      return { deleted: result.count };
+    }
+
+    const depts = await this.prisma.department.findMany({
+      where: { college: collegeScope },
+      select: { code: true },
+    });
+    const deptCodes = depts.map((d) => d.code);
+
+    await this.prisma.schedule.deleteMany({
+      where: { course: { departmentCode: { in: deptCodes } } },
+    });
+    await this.prisma.examSchedule.deleteMany({
+      where: { course: { departmentCode: { in: deptCodes } } },
+    });
+
+    const courseCodes = (
+      await this.prisma.course.findMany({
+        where: { departmentCode: { in: deptCodes } },
+        select: { code: true },
+      })
+    ).map((c) => c.code);
+
+    await this.prisma.courseAlias.deleteMany({
+      where: {
+        OR: [
+          { primaryCode: { in: courseCodes } },
+          { aliasCode: { in: courseCodes } },
+        ],
+      },
+    });
+
+    const result = await this.prisma.course.deleteMany({
+      where: { departmentCode: { in: deptCodes } },
+    });
     return { deleted: result.count };
   }
 
-  async deleteAllDepartments(): Promise<{ deleted: number }> {
-    await this.prisma.schedule.deleteMany({});
-    await this.prisma.examSchedule.deleteMany({});
-    await this.prisma.courseAlias.deleteMany({});
-    await this.prisma.course.deleteMany({});
-    const result = await this.prisma.department.deleteMany({});
+  async deleteAllDepartments(
+    collegeScope?: College,
+  ): Promise<{ deleted: number }> {
+    if (!collegeScope) {
+      await this.prisma.schedule.deleteMany({});
+      await this.prisma.examSchedule.deleteMany({});
+      await this.prisma.courseAlias.deleteMany({});
+      await this.prisma.course.deleteMany({});
+      const result = await this.prisma.department.deleteMany({});
+      return { deleted: result.count };
+    }
+
+    await this.deleteAllCourses(collegeScope);
+    const result = await this.prisma.department.deleteMany({
+      where: { college: collegeScope },
+    });
     return { deleted: result.count };
   }
 
@@ -71,11 +142,17 @@ export class AdminService {
     };
   }
 
-  async seedDepartments(): Promise<{ created: number; skipped: number }> {
+  async seedDepartments(
+    collegeScope?: College,
+  ): Promise<{ created: number; skipped: number }> {
     let created = 0;
     let skipped = 0;
 
-    for (const dept of DEPARTMENTS_SEED) {
+    const depts: SeedDepartment[] = collegeScope
+      ? DEPARTMENTS_SEED.filter((d) => d.college === collegeScope)
+      : DEPARTMENTS_SEED;
+
+    for (const dept of depts) {
       const existing = await this.prisma.department.findUnique({
         where: { code: dept.code },
       });
@@ -90,14 +167,30 @@ export class AdminService {
     return { created, skipped };
   }
 
-  async seedCourses(): Promise<{ created: number; skipped: number }> {
+  async seedCourses(
+    collegeScope?: College,
+  ): Promise<{ created: number; skipped: number }> {
     let created = 0;
     let skipped = 0;
 
-    const allCourses = [
-      ...UNIVERSITY_COURSES_SEED,
-      ...DEPARTMENTAL_COURSES_SEED,
-    ] as SeedCourse[];
+    let allCourses: SeedCourse[];
+
+    if (collegeScope) {
+      const collegeDepts = await this.prisma.department.findMany({
+        where: { college: collegeScope },
+        select: { code: true },
+      });
+      const collegeDeptCodes = new Set(collegeDepts.map((d) => d.code));
+
+      allCourses = (DEPARTMENTAL_COURSES_SEED as SeedCourse[]).filter((c) =>
+        collegeDeptCodes.has(c.departmentCode),
+      );
+    } else {
+      allCourses = [
+        ...UNIVERSITY_COURSES_SEED,
+        ...DEPARTMENTAL_COURSES_SEED,
+      ] as SeedCourse[];
+    }
 
     for (const course of allCourses) {
       const existing = await this.prisma.course.findUnique({
@@ -149,12 +242,12 @@ export class AdminService {
     return { created, skipped };
   }
 
-  async seedAll(): Promise<{
+  async seedAll(collegeScope?: College): Promise<{
     departments: { created: number; skipped: number };
     courses: { created: number; skipped: number };
   }> {
-    const departments = await this.seedDepartments();
-    const courses = await this.seedCourses();
+    const departments = await this.seedDepartments(collegeScope);
+    const courses = await this.seedCourses(collegeScope);
     return { departments, courses };
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -82,12 +82,18 @@ export class AuthService {
         email: true,
         name: true,
         role: true,
+        collegeCode: true,
         departmentCode: true,
         createdAt: true,
       },
     });
 
-    const tokens = await this.generateTokens(user.id, user.email, user.role);
+    const tokens = await this.generateTokens(
+      user.id,
+      user.email,
+      user.role,
+      user.collegeCode ?? undefined,
+    );
     return { user, ...tokens };
   }
 
@@ -110,13 +116,19 @@ export class AuthService {
       data: { lastLoginAt: new Date() },
     });
 
-    const tokens = await this.generateTokens(user.id, user.email, user.role);
+    const tokens = await this.generateTokens(
+      user.id,
+      user.email,
+      user.role,
+      user.collegeCode ?? undefined,
+    );
     return {
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
         role: user.role,
+        collegeCode: user.collegeCode,
       },
       ...tokens,
     };
@@ -125,7 +137,13 @@ export class AuthService {
   async validateUser(userId: string) {
     return this.prisma.user.findUnique({
       where: { id: userId, isActive: true },
-      select: { id: true, email: true, name: true, role: true },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        collegeCode: true,
+      },
     });
   }
 
@@ -200,6 +218,7 @@ export class AuthService {
         name: true,
         role: true,
         phone: true,
+        collegeCode: true,
         departmentCode: true,
         department: { select: { name: true, code: true } },
         createdAt: true,
@@ -217,8 +236,16 @@ export class AuthService {
     };
   }
 
-  private async generateTokens(userId: string, email: string, role: string) {
-    const payload = { sub: userId, email, role };
+  private async generateTokens(
+    userId: string,
+    email: string,
+    role: string,
+    collegeCode?: string,
+  ) {
+    const payload: Record<string, unknown> = { sub: userId, email, role };
+    if (collegeCode) {
+      payload.collegeCode = collegeCode;
+    }
     const accessToken = await this.jwtService.signAsync(payload);
     return { access_token: accessToken, token_type: 'Bearer' };
   }

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { College } from '../../../generated/prisma';
 
 interface JwtPayload {
   sub: string;
   matricNO?: string;
   email: string;
   role: string;
+  collegeCode?: College;
 }
 
 interface ValidatedUser {
@@ -15,6 +17,7 @@ interface ValidatedUser {
   matricNO?: string;
   email: string;
   role: string;
+  collegeCode?: College;
 }
 
 @Injectable()
@@ -33,6 +36,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       matricNO: payload.matricNO,
       email: payload.email,
       role: payload.role,
+      collegeCode: payload.collegeCode,
     };
   }
 }

--- a/src/modules/complaints/complaints.controller.ts
+++ b/src/modules/complaints/complaints.controller.ts
@@ -27,10 +27,12 @@ import { AuthenticatedRequest } from '../../common/types/auth.types';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { PaginationOptions } from '../../common/interfaces/base-service.interface';
 import { SkipHodGuard } from '../../common/decorators/skip-hod-guard.decorator';
+import { SkipCollegeGuard } from '../../common/decorators/skip-college-guard.decorator';
 
 @ApiTags('Complaints')
 @ApiBearerAuth('JWT-auth')
 @Controller('complaints')
+@SkipCollegeGuard()
 @CrudRoles({
   create: [Role.STUDENT, Role.ADMIN],
   read: [Role.ADMIN],
@@ -57,7 +59,7 @@ export class ComplaintsController extends BaseController<
   }
 
   @Get('my-complaints')
-  @Roles(Role.STUDENT, Role.ADMIN, Role.HOD, Role.LECTURER)
+  @Roles(Role.STUDENT, Role.ADMIN, Role.HOD, Role.LECTURER, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiOperation({ summary: 'Get my complaints' })
   findUserComplaints(@Req() req: AuthenticatedRequest) {
@@ -66,20 +68,12 @@ export class ComplaintsController extends BaseController<
 
   @Get('pending')
   @ApiOperation({ summary: 'Get pending complaints (Admin only)' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'orderBy', required: false, type: String })
-  @ApiQuery({ name: 'orderDirection', required: false, enum: ['asc', 'desc'] })
   findPending() {
     return this.complaintsService.findPending();
   }
 
   @Get('resolved')
   @ApiOperation({ summary: 'Get resolved complaints (Admin only)' })
-  @ApiQuery({ name: 'page', required: false, type: Number })
-  @ApiQuery({ name: 'limit', required: false, type: Number })
-  @ApiQuery({ name: 'orderBy', required: false, type: String })
-  @ApiQuery({ name: 'orderDirection', required: false, enum: ['asc', 'desc'] })
   findResolved() {
     return this.complaintsService.findResolved();
   }
@@ -92,11 +86,7 @@ export class ComplaintsController extends BaseController<
   }
 
   @Patch(':id/status')
-  @ApiOperation({
-    summary: 'Update complaint status (Admin only)',
-    description:
-      'Update the status of a complaint. Available statuses: PENDING, IN_PROGRESS, RESOLVED, CLOSED',
-  })
+  @ApiOperation({ summary: 'Update complaint status (Admin only)' })
   @ApiParam({
     name: 'id',
     description: 'Complaint ID',

--- a/src/modules/course-aliases/course-aliases.controller.ts
+++ b/src/modules/course-aliases/course-aliases.controller.ts
@@ -9,16 +9,18 @@ import { CourseAliasesService } from './course-aliases.service';
 import { CreateCourseAliasDto } from './dto/create-course-alias.dto';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { SkipHodGuard } from '../../common/decorators/skip-hod-guard.decorator';
+import { SkipCollegeGuard } from '../../common/decorators/skip-college-guard.decorator';
 import { Role } from '../../generated/prisma';
 
 @ApiTags('Course Aliases')
 @ApiBearerAuth('JWT-auth')
 @Controller('course-aliases')
+@SkipCollegeGuard()
 export class CourseAliasesController {
   constructor(private readonly courseAliasesService: CourseAliasesService) {}
 
   @Post()
-  @Roles(Role.ADMIN, Role.HOD)
+  @Roles(Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiOperation({ summary: 'Link two courses as aliases of each other' })
   create(@Body() dto: CreateCourseAliasDto) {
@@ -39,7 +41,7 @@ export class CourseAliasesController {
   }
 
   @Delete(':id')
-  @Roles(Role.ADMIN, Role.HOD)
+  @Roles(Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiOperation({ summary: 'Remove a course alias relationship' })
   @ApiParam({ name: 'id', type: 'string' })

--- a/src/modules/courses/courses.controller.ts
+++ b/src/modules/courses/courses.controller.ts
@@ -11,6 +11,7 @@ import {
   UseInterceptors,
   Res,
   BadRequestException,
+  Req,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Response as ExpressResponse } from 'express';
@@ -34,14 +35,15 @@ import { CourseFilterDto } from './dto/course-filter.dto';
 import { BaseController } from '../../common/controllers/base.controller';
 import { CrudRoles } from '../../common/decorators/crud-roles.decorator';
 import { Course, Role } from '../../generated/prisma';
+import { AuthenticatedRequest } from '../../common/types/auth.types';
 
 @ApiTags('Courses')
 @Controller('courses')
 @CrudRoles({
-  create: [Role.ADMIN, Role.HOD],
+  create: [Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN],
   read: [],
-  update: [Role.ADMIN, Role.HOD],
-  delete: [Role.ADMIN],
+  update: [Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN],
+  delete: [Role.ADMIN, Role.COLLEGE_ADMIN],
 })
 export class CoursesController extends BaseController<
   Course,
@@ -92,7 +94,10 @@ export class CoursesController extends BaseController<
   @Post('bulk/upload')
   @UseInterceptors(FileInterceptor('file'))
   @ApiBulkCreateCourses()
-  async bulkCreateFromCsv(@UploadedFile() file: Express.Multer.File) {
+  async bulkCreateFromCsv(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
     if (!file) {
       throw new BadRequestException('No file uploaded');
     }
@@ -101,7 +106,10 @@ export class CoursesController extends BaseController<
       throw new BadRequestException('File must be a CSV');
     }
 
-    return this.coursesService.bulkCreateFromCsv(file.buffer);
+    return this.coursesService.bulkCreateFromCsv(
+      file.buffer,
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Get(':code')

--- a/src/modules/courses/courses.service.ts
+++ b/src/modules/courses/courses.service.ts
@@ -15,7 +15,7 @@ import {
   BulkOperationResult,
   CsvValidationError,
 } from '../../common/dto/csv-bulk.dto';
-import { Course, Level, Role } from '../../generated/prisma';
+import { College, Course, Level, Role } from '../../generated/prisma';
 import { PaginatedResult } from '../../common/interfaces/base-service.interface';
 
 export interface CourseWithAliasWarnings extends Course {
@@ -207,6 +207,7 @@ export class CoursesService extends BaseService<
 
   async bulkCreateFromCsv(
     buffer: Buffer,
+    collegeScope?: College,
   ): Promise<BulkOperationResult<Course>> {
     const requiredHeaders = [
       'code',
@@ -226,6 +227,39 @@ export class CoursesService extends BaseService<
 
     if (data.length === 0) {
       return this.csvService.createBulkResult([], allErrors, errors.length);
+    }
+
+    if (collegeScope) {
+      const deptCodes = [...new Set(data.map((r) => r.departmentCode))];
+      const depts = await this.prisma.department.findMany({
+        where: { code: { in: deptCodes } },
+        select: { code: true, college: true },
+      });
+      const deptCollegeMap = new Map(depts.map((d) => [d.code, d.college]));
+
+      for (let i = 0; i < data.length; i++) {
+        const row = data[i];
+        const deptCollege = deptCollegeMap.get(row.departmentCode);
+        if (deptCollege && deptCollege !== collegeScope) {
+          allErrors.push({
+            row: i + 2,
+            field: 'departmentCode',
+            value: row.departmentCode,
+            message: `Department '${row.departmentCode}' does not belong to your college (${collegeScope})`,
+          });
+        }
+      }
+
+      const errorRows = new Set(allErrors.map((e) => e.row));
+      const filteredData = data.filter((_, i) => !errorRows.has(i + 2));
+
+      if (filteredData.length === 0) {
+        return this.csvService.createBulkResult(
+          [],
+          allErrors,
+          data.length + errors.length,
+        );
+      }
     }
 
     const codeToAliasMap = new Map<string, string[]>();

--- a/src/modules/departments/departments.controller.ts
+++ b/src/modules/departments/departments.controller.ts
@@ -44,10 +44,10 @@ import { AuthenticatedRequest } from '../../common/types/auth.types';
 @ApiTags('Departments')
 @Controller('departments')
 @CrudRoles({
-  create: [Role.ADMIN],
+  create: [Role.ADMIN, Role.COLLEGE_ADMIN],
   read: [],
-  update: [Role.ADMIN],
-  delete: [Role.ADMIN],
+  update: [Role.ADMIN, Role.COLLEGE_ADMIN],
+  delete: [Role.ADMIN, Role.COLLEGE_ADMIN],
 })
 export class DepartmentsController extends BaseController<
   Department,
@@ -91,12 +91,18 @@ export class DepartmentsController extends BaseController<
   @Post('bulk/upload')
   @UseInterceptors(FileInterceptor('file'))
   @ApiBulkCreateDepartments()
-  async bulkCreateFromCsv(@UploadedFile() file: Express.Multer.File) {
+  async bulkCreateFromCsv(
+    @UploadedFile() file: Express.Multer.File,
+    @Req() req: AuthenticatedRequest,
+  ) {
     if (!file) throw new BadRequestException('No file uploaded');
     if (file.mimetype !== 'text/csv' && !file.originalname.endsWith('.csv')) {
       throw new BadRequestException('File must be a CSV');
     }
-    return this.departmentsService.bulkCreateFromCsv(file.buffer);
+    return this.departmentsService.bulkCreateFromCsv(
+      file.buffer,
+      req.user.role === Role.COLLEGE_ADMIN ? req.user.collegeCode : undefined,
+    );
   }
 
   @Get(':code/programmes')
@@ -124,7 +130,7 @@ export class DepartmentsController extends BaseController<
   }
 
   @Patch(':code/schedule/lock')
-  @Roles(Role.HOD, Role.ADMIN)
+  @Roles(Role.HOD, Role.ADMIN, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiLockDepartmentSchedule()
   lockSchedule(@Param('code') code: string, @Req() req: AuthenticatedRequest) {
@@ -132,7 +138,7 @@ export class DepartmentsController extends BaseController<
   }
 
   @Patch(':code/schedule/unlock')
-  @Roles(Role.HOD, Role.ADMIN)
+  @Roles(Role.HOD, Role.ADMIN, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiUnlockDepartmentSchedule()
   unlockSchedule(

--- a/src/modules/departments/departments.service.ts
+++ b/src/modules/departments/departments.service.ts
@@ -17,7 +17,7 @@ import {
   BulkOperationResult,
   CsvValidationError,
 } from '../../common/dto/csv-bulk.dto';
-import { Department, Role } from '../../generated/prisma';
+import { College, Department, Role } from '../../generated/prisma';
 import { PaginatedResult } from '../../common/interfaces/base-service.interface';
 
 @Injectable()
@@ -54,6 +54,7 @@ export class DepartmentsService extends BaseService<
         { code: { contains: query.searchTerm, mode: 'insensitive' } },
       ];
     }
+    if (query.college) where.college = query.college;
     if (query.hasCourses) where.courses = { some: { isActive: true } };
     if (query.withoutCourses) where.courses = { none: { isActive: true } };
 
@@ -135,11 +136,17 @@ export class DepartmentsService extends BaseService<
 
   async lockSchedule(
     code: string,
-    requestingUser: { id: string; role: string },
+    requestingUser: { id: string; role: string; collegeCode?: College },
   ): Promise<Department> {
-    await this.findOne(code);
+    const dept = await this.findOne(code);
     if (requestingUser.role === Role.HOD) {
       await this.assertHodOwnsDepartment(requestingUser.id, code);
+    }
+    if (requestingUser.role === Role.COLLEGE_ADMIN) {
+      this.assertCollegeAdminOwnsDepartment(
+        requestingUser.collegeCode,
+        (dept as unknown as { college: College }).college,
+      );
     }
     return this.prisma.department.update({
       where: { code },
@@ -152,11 +159,17 @@ export class DepartmentsService extends BaseService<
 
   async unlockSchedule(
     code: string,
-    requestingUser: { id: string; role: string },
+    requestingUser: { id: string; role: string; collegeCode?: College },
   ): Promise<Department> {
-    await this.findOne(code);
+    const dept = await this.findOne(code);
     if (requestingUser.role === Role.HOD) {
       await this.assertHodOwnsDepartment(requestingUser.id, code);
+    }
+    if (requestingUser.role === Role.COLLEGE_ADMIN) {
+      this.assertCollegeAdminOwnsDepartment(
+        requestingUser.collegeCode,
+        (dept as unknown as { college: College }).college,
+      );
     }
     return this.prisma.department.update({
       where: { code },
@@ -165,6 +178,17 @@ export class DepartmentsService extends BaseService<
         hod: { select: { id: true, name: true, email: true, role: true } },
       },
     });
+  }
+
+  private assertCollegeAdminOwnsDepartment(
+    adminCollege: College | undefined,
+    deptCollege: College,
+  ): void {
+    if (!adminCollege || adminCollege !== deptCollege) {
+      throw new ForbiddenException(
+        'College admins can only manage departments within their own college',
+      );
+    }
   }
 
   private async assertHodOwnsDepartment(
@@ -215,6 +239,7 @@ export class DepartmentsService extends BaseService<
 
   async bulkCreateFromCsv(
     buffer: Buffer,
+    collegeScope?: College,
   ): Promise<BulkOperationResult<Department>> {
     const { data, errors } = await this.csvService.parseCsvFile(
       buffer,
@@ -226,10 +251,14 @@ export class DepartmentsService extends BaseService<
     if (data.length === 0)
       return this.csvService.createBulkResult([], allErrors, errors.length);
 
+    const rows = data.map((d) => ({
+      code: d.code,
+      name: d.name,
+      ...(collegeScope ? { college: collegeScope } : {}),
+    }));
+
     const { created, errors: repositoryErrors } =
-      await this.departmentRepository.bulkCreateWithValidation(
-        data.map((d) => ({ code: d.code, name: d.name })),
-      );
+      await this.departmentRepository.bulkCreateWithValidation(rows);
 
     for (const repoError of repositoryErrors) {
       allErrors.push({

--- a/src/modules/departments/dto/department-filter.dto.ts
+++ b/src/modules/departments/dto/department-filter.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { IsOptional, IsString, IsBoolean, IsEnum } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { College } from '../../../generated/prisma';
 import { PaginationDto } from '../../../common/dto/pagination.dto';
 
 export class DepartmentFilterDto extends PaginationDto {
@@ -10,6 +11,11 @@ export class DepartmentFilterDto extends PaginationDto {
   @IsOptional()
   @IsString()
   searchTerm?: string;
+
+  @ApiPropertyOptional({ enum: College, description: 'Filter by college' })
+  @IsOptional()
+  @IsEnum(College)
+  college?: College;
 
   @ApiPropertyOptional({
     description: 'Filter only departments with active courses',

--- a/src/modules/exams/exams.controller.ts
+++ b/src/modules/exams/exams.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Delete,
   Query,
+  Req,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { ExamsService } from './exams.service';
@@ -17,6 +18,7 @@ import { BaseController } from '../../common/controllers/base.controller';
 import { CrudRoles } from '../../common/decorators/crud-roles.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { SkipHodGuard } from '../../common/decorators/skip-hod-guard.decorator';
+import { SkipCollegeGuard } from '../../common/decorators/skip-college-guard.decorator';
 import { ExamSchedule, Role } from '../../generated/prisma';
 import { PaginationOptions } from '../../common/interfaces/base-service.interface';
 import {
@@ -28,14 +30,15 @@ import {
   ApiGenerateExamTimetable,
   ApiGetCoursesWithoutExams,
 } from './decorators/exam-api.decorator';
+import { AuthenticatedRequest } from '../../common/types/auth.types';
 
 @ApiTags('Exams')
 @Controller('exams')
 @CrudRoles({
-  create: [Role.ADMIN],
+  create: [Role.ADMIN, Role.COLLEGE_ADMIN],
   read: [],
-  update: [Role.ADMIN],
-  delete: [Role.ADMIN],
+  update: [Role.ADMIN, Role.COLLEGE_ADMIN],
+  delete: [Role.ADMIN, Role.COLLEGE_ADMIN],
 })
 export class ExamsController extends BaseController<
   ExamSchedule,
@@ -47,15 +50,20 @@ export class ExamsController extends BaseController<
   }
 
   @Post('generate')
-  @Roles(Role.ADMIN)
+  @Roles(Role.ADMIN, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
+  @SkipCollegeGuard()
   @ApiGenerateExamTimetable()
-  generate(@Body() dto: GenerateExamTimetableDto) {
-    return this.examsService.generateExamTimetable(dto);
+  generate(
+    @Body() dto: GenerateExamTimetableDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.examsService.generateExamTimetable(dto, req.user);
   }
 
   @Get('without-exams')
   @SkipHodGuard()
+  @SkipCollegeGuard()
   @ApiGetCoursesWithoutExams()
   getCoursesWithoutExams() {
     return this.examsService.getCoursesWithoutExams();

--- a/src/modules/exams/exams.service.ts
+++ b/src/modules/exams/exams.service.ts
@@ -12,6 +12,7 @@ import {
   Course,
   ExamSchedule,
   Level,
+  Role,
   VenueType,
 } from '../../generated/prisma';
 import {
@@ -208,7 +209,13 @@ export class ExamsService extends BaseService<
 
   async generateExamTimetable(
     dto: GenerateExamTimetableDto,
+    requestingUser?: { role: string; collegeCode?: College },
   ): Promise<GenerateExamTimetableResult> {
+    const collegeScope =
+      requestingUser?.role === Role.COLLEGE_ADMIN
+        ? requestingUser.collegeCode
+        : undefined;
+
     const session = dto.sessionId
       ? await this.prisma.academicSession.findUnique({
           where: { id: dto.sessionId },
@@ -238,8 +245,14 @@ export class ExamsService extends BaseService<
       courseFilter.level = dto.level;
     }
 
-    if (dto.college) {
-      courseFilter.department = { college: dto.college };
+    const effectiveCollege = collegeScope ?? dto.college;
+
+    if (effectiveCollege) {
+      courseFilter.department = { college: effectiveCollege };
+    }
+
+    if (collegeScope) {
+      courseFilter.isGeneral = false;
     }
 
     const courses = await this.prisma.course.findMany({
@@ -255,7 +268,7 @@ export class ExamsService extends BaseService<
         semester: dto.semester,
         departmentCode: dto.departmentCode ?? null,
         level: dto.level ?? null,
-        college: dto.college ?? null,
+        college: effectiveCollege ?? null,
         totalCourses: 0,
         scheduledExams: 0,
         skippedCourses: [],
@@ -313,7 +326,7 @@ export class ExamsService extends BaseService<
             if (slotsUsed < venuePool.length) {
               const venue = venuePool[slotsUsed % venuePool.length];
               const targetCollege = course.isGeneral
-                ? (dto.college ?? course.department.college)
+                ? (effectiveCollege ?? course.department.college)
                 : null;
 
               scheduledExams.push({
@@ -359,7 +372,7 @@ export class ExamsService extends BaseService<
       semester: dto.semester,
       departmentCode: dto.departmentCode ?? null,
       level: dto.level ?? null,
-      college: dto.college ?? null,
+      college: effectiveCollege ?? null,
       totalCourses: courses.length,
       scheduledExams: scheduledExams.length,
       skippedCourses,

--- a/src/modules/schedules/schedules.controller.ts
+++ b/src/modules/schedules/schedules.controller.ts
@@ -36,10 +36,10 @@ import { AuthenticatedRequest } from '../../common/types/auth.types';
 @ApiTags('Schedules')
 @Controller('schedules')
 @CrudRoles({
-  create: [Role.ADMIN, Role.HOD],
+  create: [Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN],
   read: [],
-  update: [Role.ADMIN, Role.HOD],
-  delete: [Role.ADMIN, Role.HOD],
+  update: [Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN],
+  delete: [Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN],
 })
 export class SchedulesController extends BaseController<
   Schedule,
@@ -51,7 +51,7 @@ export class SchedulesController extends BaseController<
   }
 
   @Post('generate')
-  @Roles(Role.ADMIN, Role.HOD)
+  @Roles(Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiGenerateSchedules()
   async generate(
@@ -62,7 +62,7 @@ export class SchedulesController extends BaseController<
   }
 
   @Post('generate/batch')
-  @Roles(Role.ADMIN, Role.HOD)
+  @Roles(Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiGenerateSchedulesBatch()
   async generateBatch(
@@ -104,7 +104,7 @@ export class SchedulesController extends BaseController<
   }
 
   @Patch(':id/toggle-fixed')
-  @Roles(Role.ADMIN, Role.HOD)
+  @Roles(Role.ADMIN, Role.HOD, Role.COLLEGE_ADMIN)
   @SkipHodGuard()
   @ApiToggleScheduleFixed()
   toggleFixed(@Param('id') id: string, @Req() req: AuthenticatedRequest) {

--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -375,13 +375,13 @@ export class SchedulesService extends BaseService<
         this.prisma.schedule.findMany({
           where: departmentalManualOverrideFilter,
           include: { course: { include: { department: true } } },
-        }),
+        }) as Promise<Schedule[]>,
         collegeScope
           ? Promise.resolve([])
-          : this.prisma.schedule.findMany({
+          : (this.prisma.schedule.findMany({
               where: generalScheduledFilter,
               include: { course: { include: { department: true } } },
-            }),
+            }) as Promise<Schedule[]>),
       ]);
 
     const overriddenCourseCodes = new Set<string>([

--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -23,7 +23,13 @@ import {
   CourseInput,
   ScheduleAssignment,
 } from './scheduler/scheduler.engine';
-import { DayOfWeek, Level, Role, Schedule } from '../../generated/prisma';
+import {
+  College,
+  DayOfWeek,
+  Level,
+  Role,
+  Schedule,
+} from '../../generated/prisma';
 import { PaginatedResult } from '../../common/interfaces/base-service.interface';
 
 @Injectable()
@@ -227,7 +233,7 @@ export class SchedulesService extends BaseService<
 
   async generateSchedules(
     dto: GenerateScheduleDto,
-    requestingUser: { id: string; role: string },
+    requestingUser: { id: string; role: string; collegeCode?: College },
   ): Promise<GenerateScheduleResult> {
     const session = dto.sessionId
       ? await this.prisma.academicSession.findUnique({
@@ -262,6 +268,8 @@ export class SchedulesService extends BaseService<
       departmentCode = hodUser.managedDepartment.code;
     }
 
+    const collegeScope = this.resolveCollegeScope(requestingUser);
+
     const lockedDepartmentCodes =
       await this.resolveLockedDepartmentCodes(departmentCode);
 
@@ -273,10 +281,15 @@ export class SchedulesService extends BaseService<
 
     if (departmentCode) {
       departmentalCourseFilter.departmentCode = departmentCode;
-    } else if (lockedDepartmentCodes.length > 0) {
-      departmentalCourseFilter.departmentCode = {
-        notIn: lockedDepartmentCodes,
-      };
+    } else {
+      if (collegeScope) {
+        departmentalCourseFilter.department = { college: collegeScope };
+      }
+      if (lockedDepartmentCodes.length > 0) {
+        departmentalCourseFilter.departmentCode = {
+          notIn: lockedDepartmentCodes,
+        };
+      }
     }
 
     if (level) departmentalCourseFilter.level = level;
@@ -294,10 +307,12 @@ export class SchedulesService extends BaseService<
         where: departmentalCourseFilter,
         include: { department: true },
       }),
-      this.prisma.course.findMany({
-        where: universityCourseFilter,
-        include: { department: true },
-      }),
+      collegeScope
+        ? Promise.resolve([])
+        : this.prisma.course.findMany({
+            where: universityCourseFilter,
+            include: { department: true },
+          }),
     ]);
 
     const allCourses = [...departmentalCourses, ...universityCourses];
@@ -335,8 +350,13 @@ export class SchedulesService extends BaseService<
 
     if (departmentCode) {
       deptManualCourseCond.departmentCode = departmentCode;
-    } else if (lockedDepartmentCodes.length > 0) {
-      deptManualCourseCond.departmentCode = { notIn: lockedDepartmentCodes };
+    } else {
+      if (collegeScope) {
+        deptManualCourseCond.department = { college: collegeScope };
+      }
+      if (lockedDepartmentCodes.length > 0) {
+        deptManualCourseCond.departmentCode = { notIn: lockedDepartmentCodes };
+      }
     }
 
     if (level) deptManualCourseCond.level = level;
@@ -356,10 +376,12 @@ export class SchedulesService extends BaseService<
           where: departmentalManualOverrideFilter,
           include: { course: { include: { department: true } } },
         }),
-        this.prisma.schedule.findMany({
-          where: generalScheduledFilter,
-          include: { course: { include: { department: true } } },
-        }),
+        collegeScope
+          ? Promise.resolve([])
+          : this.prisma.schedule.findMany({
+              where: generalScheduledFilter,
+              include: { course: { include: { department: true } } },
+            }),
       ]);
 
     const overriddenCourseCodes = new Set<string>([
@@ -405,10 +427,15 @@ export class SchedulesService extends BaseService<
 
     if (departmentCode) {
       autoDeleteDeptCourseCond.departmentCode = departmentCode;
-    } else if (lockedDepartmentCodes.length > 0) {
-      autoDeleteDeptCourseCond.departmentCode = {
-        notIn: lockedDepartmentCodes,
-      };
+    } else {
+      if (collegeScope) {
+        autoDeleteDeptCourseCond.department = { college: collegeScope };
+      }
+      if (lockedDepartmentCodes.length > 0) {
+        autoDeleteDeptCourseCond.departmentCode = {
+          notIn: lockedDepartmentCodes,
+        };
+      }
     }
 
     if (level) autoDeleteDeptCourseCond.level = level;
@@ -434,7 +461,9 @@ export class SchedulesService extends BaseService<
 
     await this.prisma.$transaction(async (tx) => {
       await tx.schedule.deleteMany({ where: autoDeleteDepartmentalFilter });
-      await tx.schedule.deleteMany({ where: autoDeleteUniversityFilter });
+      if (!collegeScope) {
+        await tx.schedule.deleteMany({ where: autoDeleteUniversityFilter });
+      }
 
       if (assignments.length > 0) {
         await tx.schedule.createMany({
@@ -473,7 +502,7 @@ export class SchedulesService extends BaseService<
 
   async generateSchedulesBatch(
     dto: GenerateScheduleDto,
-    requestingUser: { id: string; role: string },
+    requestingUser: { id: string; role: string; collegeCode?: College },
   ): Promise<BatchGenerateScheduleResult> {
     if (requestingUser.role === Role.HOD) {
       const result = await this.generateSchedules(dto, requestingUser);
@@ -491,6 +520,8 @@ export class SchedulesService extends BaseService<
         errors: [],
       };
     }
+
+    const collegeScope = this.resolveCollegeScope(requestingUser);
 
     const session = dto.sessionId
       ? await this.prisma.academicSession.findUnique({
@@ -517,10 +548,12 @@ export class SchedulesService extends BaseService<
     };
     if (dto.level) universityCourseFilter.level = dto.level;
 
-    const universityCourses = await this.prisma.course.findMany({
-      where: universityCourseFilter,
-      include: { department: true },
-    });
+    const universityCourses = collegeScope
+      ? []
+      : await this.prisma.course.findMany({
+          where: universityCourseFilter,
+          include: { department: true },
+        });
 
     const aliasMap = await this.buildAliasMap(
       universityCourses.map((c) => c.code),
@@ -543,14 +576,16 @@ export class SchedulesService extends BaseService<
       }),
     );
 
-    const existingUniversitySchedules = await this.prisma.schedule.findMany({
-      where: {
-        sessionId: session.id,
-        semester: dto.semester,
-        course: { isGeneral: true },
-      },
-      include: { course: { include: { department: true } } },
-    });
+    const existingUniversitySchedules = collegeScope
+      ? []
+      : await this.prisma.schedule.findMany({
+          where: {
+            sessionId: session.id,
+            semester: dto.semester,
+            course: { isGeneral: true },
+          },
+          include: { course: { include: { department: true } } },
+        });
 
     const overriddenUniversityCodes = new Set(
       existingUniversitySchedules
@@ -631,14 +666,16 @@ export class SchedulesService extends BaseService<
       }
     }
 
-    const allUniversitySchedules = await this.prisma.schedule.findMany({
-      where: {
-        sessionId: session.id,
-        semester: dto.semester,
-        course: { isGeneral: true },
-      },
-      include: { course: { include: { department: true } } },
-    });
+    const allUniversitySchedules = collegeScope
+      ? []
+      : await this.prisma.schedule.findMany({
+          where: {
+            sessionId: session.id,
+            semester: dto.semester,
+            course: { isGeneral: true },
+          },
+          include: { course: { include: { department: true } } },
+        });
 
     const globalUniversityLocked: LockedSlot[] = allUniversitySchedules.map(
       (s) => ({
@@ -654,13 +691,24 @@ export class SchedulesService extends BaseService<
       }),
     );
 
+    const departmentFilter: Record<string, any> = {
+      isActive: true,
+      code: { notIn: Array.from(lockedCodes) },
+    };
+
+    if (dto.departmentCode) {
+      departmentFilter.code = dto.departmentCode;
+    } else if (collegeScope) {
+      departmentFilter.college = collegeScope;
+      if (lockedCodes.size > 0) {
+        departmentFilter.code = { notIn: Array.from(lockedCodes) };
+      }
+    }
+
     const departments = dto.departmentCode
       ? [{ code: dto.departmentCode }]
       : await this.prisma.department.findMany({
-          where: {
-            isActive: true,
-            code: { notIn: Array.from(lockedCodes) },
-          },
+          where: departmentFilter,
           select: { code: true },
           orderBy: { code: 'asc' },
         });
@@ -834,6 +882,19 @@ export class SchedulesService extends BaseService<
     };
   }
 
+  private resolveCollegeScope(requestingUser: {
+    role: string;
+    collegeCode?: College;
+  }): College | null {
+    if (
+      requestingUser.role === Role.COLLEGE_ADMIN &&
+      requestingUser.collegeCode
+    ) {
+      return requestingUser.collegeCode;
+    }
+    return null;
+  }
+
   private async buildAliasMap(
     courseCodes: string[],
   ): Promise<Map<string, string[]>> {
@@ -865,7 +926,7 @@ export class SchedulesService extends BaseService<
 
   async toggleFixed(
     id: string,
-    requestingUser: { id: string; role: string },
+    requestingUser: { id: string; role: string; collegeCode?: College },
   ): Promise<Schedule> {
     const schedule = await this.prisma.schedule.findUnique({
       where: { id },
@@ -896,6 +957,18 @@ export class SchedulesService extends BaseService<
       if (schedule.course.departmentCode !== hodUser.managedDepartment.code) {
         throw new ForbiddenException(
           'HODs can only pin or unpin schedules in their own department',
+        );
+      }
+    }
+
+    if (requestingUser.role === Role.COLLEGE_ADMIN) {
+      if (
+        !requestingUser.collegeCode ||
+        (schedule.course.department as unknown as { college: College })
+          .college !== requestingUser.collegeCode
+      ) {
+        throw new ForbiddenException(
+          'College admins can only pin or unpin schedules within their own college',
         );
       }
     }

--- a/src/modules/users/dto/create-user.dto.ts
+++ b/src/modules/users/dto/create-user.dto.ts
@@ -9,7 +9,7 @@ import {
   Matches,
   ValidateIf,
 } from 'class-validator';
-import { Role } from '../../../generated/prisma';
+import { College, Role } from '../../../generated/prisma';
 
 export class CreateUserDto {
   @ApiProperty({ example: 'CS/2023/001' })
@@ -60,4 +60,15 @@ export class CreateUserDto {
   )
   @IsNotEmpty()
   departmentCode?: string;
+
+  @ApiProperty({
+    enum: College,
+    required: false,
+    description: 'Required when role is COLLEGE_ADMIN',
+  })
+  @IsEnum(College)
+  @ValidateIf((o: CreateUserDto) => o.role === Role.COLLEGE_ADMIN)
+  @IsNotEmpty()
+  @IsOptional()
+  collegeCode?: College;
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -68,6 +68,7 @@ export class UsersService extends BaseService<
 
   protected async beforeUpdate(
     dto: UpdateUserDto,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _identifier: string,
   ): Promise<Record<string, any>> {
     const data: Record<string, any> = { ...dto };
@@ -267,7 +268,8 @@ export class UsersService extends BaseService<
   }
 
   private excludePassword(user: User): Omit<User, 'password'> {
-    const { password: _password, ...rest } = user;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password, ...rest } = user;
     return rest;
   }
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -54,6 +54,12 @@ export class UsersService extends BaseService<
       }
     }
 
+    if (role === Role.COLLEGE_ADMIN && !dto.collegeCode) {
+      throw new BadRequestException(
+        'College code is required for COLLEGE_ADMIN role',
+      );
+    }
+
     return {
       ...dto,
       password: await argon2.hash(dto.password),
@@ -62,7 +68,6 @@ export class UsersService extends BaseService<
 
   protected async beforeUpdate(
     dto: UpdateUserDto,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _identifier: string,
   ): Promise<Record<string, any>> {
     const data: Record<string, any> = { ...dto };
@@ -262,7 +267,6 @@ export class UsersService extends BaseService<
   }
 
   private excludePassword(user: User): Omit<User, 'password'> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { password: _password, ...rest } = user;
     return rest;
   }


### PR DESCRIPTION

This PR introduces a multi-college management system and refactors seeding logic.

Key changes:

- Added college admin role with scope-limited access to manage courses, departments, and schedules within their own college
- Retained super admin role for cross-college management and general courses mandatory for all students of a given level
- Refactored `prisma/seed.ts` to seed only admin users (super admin and college admins)
- Moved course seeding from seed file to internal management interface